### PR TITLE
changed import of SortedDict

### DIFF
--- a/chartit/chartdata.py
+++ b/chartit/chartdata.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from itertools import groupby, chain, islice
 from operator import itemgetter
 # use SortedDict instead of native OrderedDict for Python 2.6 compatibility
-from django.utils.datastructures import SortedDict
+from collections import SortedDict
 from validation import clean_dps, clean_pdps
 from chartit.validation import clean_sortf_mapf_mts
 


### PR DESCRIPTION
According to https://github.com/aljosa/django-tinymce/issues/114, the location of SortedDict has changed. 
